### PR TITLE
Template Updates for Proper Bug Labeling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -2,7 +2,7 @@
 name: Bug
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: "\U0001F41B Bug, Bug, bug"
 assignees: ''
 
 ---
@@ -15,9 +15,9 @@ assignees: ''
 
 ## Steps to Reproduce the Problem
 
-  1.
+1.
 
 ## Specifications
 
-  - Version:
-  - Platform:
+- Version:
+- Platform:


### PR DESCRIPTION
## What it Does

Updates the bug template to apply every variation of "Bug" in our repositories. Currently, only repos with the `bug` label would get any label when using this template. The default bug label added for new repositories used to "Bug" (e.g., https://github.com/Lickability/code-snippets) and is now "🐛Bug" (e.g. https://github.com/Lickability/Scorecard/). Since changes to our organization list don’t change labels on _existing_ repositories, I’ve included all three.

Since Scorecard and code-snippets get _no_ label when creating a bug, and e.g https://github.com/Lickability/Name-Remover does, it’s my hope that only the available label will get applied.

## How to Test

Once this is merged (😬) attempt to open an issue in Scorecard, code-snippets, and Name-Remover, and make sure it gets its project-specific "bug" label, and no others. You don’t have to complete the opening of the issue, just look at the labels field in the new issue editor.

## Notes

> What’s with the syntax of that label list?!?

I created a new issue template in scorecard, which gives you a sort-of graphical editor. I selected two labels, and then opened the pull request from the resulting change. This is what those changes resulted in: https://github.com/Lickability/Scorecard/pull/1312/files

> Wait, what are those spacing changes in "Steps to Reproduce the Problem" and "Specifications"?

Since the markdown editor in GitHub is just plain text, having these indented bullets forces you to either add spaces before any new bullets you add, or be okay with the fact that your newly added bullets don’t match up with the default ones when viewing the plain text (it’ll render the same way regardless – this just bugs me a lot), for example:

```
  1. Something
2. Something else
```

## Screenshot

N/A